### PR TITLE
Fixed error when cargo responsed with code 503 - service unavailable

### DIFF
--- a/src/Logistics/LogisticsClient.php
+++ b/src/Logistics/LogisticsClient.php
@@ -148,7 +148,7 @@ class LogisticsClient extends Object
 
 	private function unexpectedResponseCode($responseCode, $expected = Response::S200_OK)
 	{
-		throw new BadResponseException("Expected '{$expected}' response code, '{$responseCode}' given.");
+		throw new BadResponseCodeException("Expected '{$expected}' response code, '{$responseCode}' given.");
 	}
 
 }

--- a/src/Logistics/LogisticsClient.php
+++ b/src/Logistics/LogisticsClient.php
@@ -2,6 +2,7 @@
 
 namespace Logistics;
 
+use Kdyby\Curl\BadStatusException;
 use Kdyby\Curl\Request;
 use Nette\Http\Response;
 use Nette\Object;
@@ -84,7 +85,7 @@ class LogisticsClient extends Object
 		$response = $this->connector->send($request);
 
 		if (($responseCode = $response->getCode()) !== Http\Response::S202_ACCEPTED) {
-			throw new BadResponseException('Expeced ' . Http\Response::S202_ACCEPTED . ' response code, ' . $responseCode . ' given.');
+			$this->unexpectedResponseCode($responseCode);
 		}
 	}
 
@@ -117,7 +118,7 @@ class LogisticsClient extends Object
 		$response = $this->connector->send($request);
 
 		if (($responseCode = $response->getCode()) !== Http\Response::S202_ACCEPTED) {
-			throw new BadResponseException('Expeced ' . Http\Response::S202_ACCEPTED . ' response code, ' . $responseCode . ' given.');
+			$this->unexpectedResponseCode($responseCode);
 		}
 	}
 
@@ -126,13 +127,28 @@ class LogisticsClient extends Object
 	public function getArrivals()
 	{
 		$request = $this->requestFactory->createRequest('arrivals')->setMethod(Request::GET);
-		$response = $this->connector->send($request);
+		try {
+			$response = $this->connector->send($request);
+		} catch (BadStatusException $e) {
+			$this->unexpectedResponseCode($e->getResponse()->getCode());
+
+			return FALSE;
+		}
 
 		if (($responseCode = $response->getCode()) !== Response::S200_OK) {
-			throw new BadResponseException('Expeced ' . Response::S200_OK . ' response code, ' . $responseCode . ' given.');
+			$this->unexpectedResponseCode($responseCode);
+
+			return FALSE;
 		}
 
 		return Json::decode($response->response, TRUE);
+	}
+
+
+
+	private function unexpectedResponseCode($responseCode, $expected = Response::S200_OK)
+	{
+		throw new BadResponseException("Expected '{$expected}' response code, '{$responseCode}' given.");
 	}
 
 }

--- a/src/Logistics/exceptions.php
+++ b/src/Logistics/exceptions.php
@@ -45,3 +45,9 @@ class InvalidConfigException extends Exception implements IException
 class BadResponseException extends Exception implements IException
 {
 }
+
+
+
+class BadResponseCodeException extends BadResponseException
+{
+}


### PR DESCRIPTION
Chytá exception z kdyby/Curl, pokud nám cargo vrátí 503 - service unavailable

Jinými slovy

```
["Jan 06 00:27:03 kebab damejidlo: damejidlo.ERROR: Kdyby\\Curl\\BadStatusException: 503 Service Unavailable in /home/users/damejidlo/damejidlo.cz/web/vendor/kdyby/curl/src/Kdyby/Curl/CurlSender.php:320 {\"at\":\"CLI: /home/users/damejidlo/damejidlo.cz/web/www/index.php damejidlo:checkArrivals\",\"tracy\":\"exception-2015-01-06-00-27-02-489c2560d647cbc01838272e2450c69f.html\"} []"]
```